### PR TITLE
React to update-dns-* lifecycle hooks only

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
 output "lambda_name" {
   description = "Lambda function name that manages DNS records"
-  value = aws_lambda_function.update_dns.function_name
+  value       = aws_lambda_function.update_dns.function_name
 }


### PR DESCRIPTION
Don't complete blindly all ASG licecycle hooks because they can be used
for something else than updating DNS.
