### PR TITLE
fix: upgrade lambda-monitored to 1.1.1 for Vanta S3 compliance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ Test parameters are configurable: `TEST_REGION`, `TEST_ROLE`, `TEST_SELECTOR`.
 **Event flow:** ASG lifecycle hook -> CloudWatch EventBridge rule -> Lambda -> Route53 + DynamoDB
 
 **Key Terraform files:**
-- `lambda.tf` — Lambda module invocation (infrahouse/lambda-monitored/aws v1.0.4),
+- `lambda.tf` — Lambda module invocation (infrahouse/lambda-monitored/aws v1.1.1),
   IAM permissions, environment variables
 - `cloudwatch.tf` — EventBridge rule and target connecting lifecycle events to Lambda
 - `dynamodb.tf` — DynamoDB lock table for concurrency control

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ See the [`examples/`](examples/) directory for working configurations:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_update_dns_lambda"></a> [update\_dns\_lambda](#module\_update\_dns\_lambda) | registry.infrahouse.com/infrahouse/lambda-monitored/aws | 1.0.4 |
+| <a name="module_update_dns_lambda"></a> [update\_dns\_lambda](#module\_update\_dns\_lambda) | registry.infrahouse.com/infrahouse/lambda-monitored/aws | 1.1.1 |
 
 ## Resources
 

--- a/lambda.tf
+++ b/lambda.tf
@@ -50,7 +50,7 @@ resource "aws_iam_policy" "lambda_permissions" {
 
 module "update_dns_lambda" {
   source  = "registry.infrahouse.com/infrahouse/lambda-monitored/aws"
-  version = "1.0.4"
+  version = "1.1.1"
 
   function_name     = "update-dns-${var.asg_name}"
   lambda_source_dir = "${path.module}/update_dns"


### PR DESCRIPTION
## Summary
- Upgrade `infrahouse/lambda-monitored/aws` from `1.0.4` to `1.1.1`
- The new version bumps the `s3-bucket` sub-module to `0.6.0`, which adds a Vanta exemption for S3 cross-region replication on the Lambda deployment artifact bucket
- Update CLAUDE.md to reflect the new version

Refs: INF-1220

## Test plan
- [ ] `terraform init -upgrade` succeeds
- [ ] `terraform plan` shows only the module version change and S3 bucket updates
- [ ] Verify Vanta no longer flags the Lambda S3 bucket for cross-region replication

🤖 Generated with [Claude Code](https://claude.com/claude-code)