### PR TITLE
feat: warm-pool-aware DNS filtering + re-raise muted handler exceptions

### DIFF
--- a/.claude/plans/plan-warm-pool-dns-filtering.md
+++ b/.claude/plans/plan-warm-pool-dns-filtering.md
@@ -1,0 +1,181 @@
+# Implementation Plan: Warm-Pool-Aware DNS Filtering (flagless)
+
+## Overview
+
+Make the update-dns Lambda correctly skip DNS work for ASG **warm-pool** lifecycle
+transitions. Today the module treats every `LAUNCHING`/`TERMINATING` event as a real
+in-service launch/terminate, which is wrong (and in one case fatal) once a consumer
+enables a warm pool. This change teaches the Lambda to recognise the two warm-pool
+transitions from the standard `Origin`/`Destination` fields and skip DNS for them,
+while still completing its own lifecycle hook.
+
+This is the upstream-ready half of the tetra-data `update-dns` fork. It is
+intentionally **flagless** — no new variables, no new Lambda env vars. The
+provisioning-readiness concern that the fork also bolted onto this module
+(`warm_pool_launch_auto_continue`) is explicitly **out of scope** and stays in the
+consumer (see "Out of scope" below).
+
+## Background / Motivation
+
+`update-dns` pairs with `website-pod`, which now ships warm-pool support
+(`website-pod` 6.1.0). So a public consumer can now enable a warm pool on the ASG —
+and the moment they do, this Lambda misbehaves:
+
+1. **`LAUNCHING` into the warm pool** (`Destination=WarmPool`): the instance is not
+   in service and serves no traffic (and in `Stopped`/`Hibernated` pools has no
+   stable IP). Adding a DNS record for it publishes an endpoint that should never
+   receive traffic. The record's correct lifecycle is created-on-activation,
+   removed-on-terminate.
+2. **`TERMINATING` from the warm pool** (`Origin=WarmPool`): a warmed instance never
+   had a DNS record. `remove_record` then crashes on the missing
+   `PublicIpAddress`/`PrivateIpAddress` tag, the hook is never completed, and it
+   hangs until `HeartbeatTimeout` -> ASG `ABANDON`. This is a hard failure, not a
+   cosmetic one.
+
+### Field availability — verified in production
+
+The whole design rests on `Origin`/`Destination` always being present. Confirmed
+against a live warm-pool ASG (`tetra-data`, account 722222646194, 45 days,
+**658 events, 0 missing either field**). Observed transition taxonomy:
+
+| Transition  | Origin -> Destination       | Count | Correct DNS action |
+|-------------|-----------------------------|-------|--------------------|
+| LAUNCHING   | EC2 -> **WarmPool**         | 207   | **skip add**       |
+| LAUNCHING   | WarmPool -> AutoScalingGroup | 175  | add (activation)   |
+| LAUNCHING   | EC2 -> AutoScalingGroup     | 38    | add (cold launch)  |
+| TERMINATING | AutoScalingGroup -> EC2     | 214   | remove             |
+| TERMINATING | **WarmPool** -> EC2         | 24    | **skip remove**    |
+
+~35% of lifecycle traffic on a warm-pool ASG (the 207 + 24) is cases the stock
+module handles incorrectly.
+
+## Problem Analysis
+
+**Location**: `update_dns/main.py`, `lambda_handler()` (the
+`TERMINATING`/`LAUNCHING` branches near the `LIFECYCLE_HOOK_*` matches).
+
+The handler matches on `LifecycleHookName` + `LifecycleTransition` only. It never
+inspects `event["detail"]["Origin"]` / `["Destination"]`, so warm-pool internal
+moves are processed as if they were real launches/terminations.
+
+## Design Decision: unconditional, positive-match on the WarmPool sentinel
+
+Skipping DNS for a warm-pool instance is never the wrong thing to do — it's a
+property of what the module is *for*, not a user preference. So this is **not**
+behind a flag (mirrors the existing always-on correctness behavior of the module).
+
+Predicates use a **positive match on `WarmPool`**, not `!= AutoScalingGroup`:
+
+- skip the **add** only when `Destination == "WarmPool"`
+- skip the **remove** only when `Origin == "WarmPool"`
+
+Why positive-match: any event that lacks the field, or carries an unexpected value,
+falls through to today's behavior (add on launch / remove on terminate). That makes
+the change provably non-breaking for every existing consumer — a non-warm-pool ASG
+only ever emits `Destination=AutoScalingGroup` (launch) and `Origin=AutoScalingGroup`
+/ `Destination=EC2` (terminate), so none of these branches ever fire for them. The
+`!= AutoScalingGroup` phrasing from the fork is deny-by-default and would skip DNS on
+a real launch if `Destination` were ever absent; we avoid it.
+
+In all skip cases the Lambda **still completes its own lifecycle hook** (CONTINUE).
+update-dns owns its hook and must release it; it simply does no DNS work.
+
+## Changes
+
+### `update_dns/main.py`
+
+Read the two fields once near the top of `lambda_handler()` (alongside
+`instance_id` / `lc_hook_name` / `lc_transition`):
+
+```python
+origin = event["detail"].get("Origin")
+destination = event["detail"].get("Destination")
+```
+
+**Terminating branch** — add a guard before acquiring the lock / `remove_record`:
+
+```python
+if origin == "WarmPool":
+    # Warm-pool instance being terminated (Warmed:* -> EC2). It never held a
+    # DNS record, and remove_record would crash on the missing IP tag. Skip
+    # DNS and complete the hook so the ASG isn't left waiting for HeartbeatTimeout.
+    LOG.info(
+        f"Terminating event Origin=WarmPool on {instance_id}; "
+        f"completing hook with no DNS removal."
+    )
+    ASG(event["detail"]["AutoScalingGroupName"]).complete_lifecycle_action(
+        hook_name=lc_hook_name, result="CONTINUE", instance_id=instance_id,
+    )
+    return
+```
+
+**Launching branch** — add a guard before acquiring the lock / `add_records`:
+
+```python
+if destination == "WarmPool":
+    # Instance entering the warm pool (EC2 -> WarmPool). Not in service, no
+    # traffic, no stable IP — no DNS record wanted. It will be registered when
+    # it activates out of the pool (Destination=AutoScalingGroup). Complete this
+    # module's hook immediately; any readiness gating is the consumer's separate
+    # hook, not ours.
+    LOG.info(
+        f"Launching event Destination=WarmPool on {instance_id}; "
+        f"completing hook with no DNS add."
+    )
+    ASG(event["detail"]["AutoScalingGroupName"]).complete_lifecycle_action(
+        hook_name=lc_hook_name, result="CONTINUE", instance_id=instance_id,
+    )
+    return
+```
+
+No other `*.tf` changes. **No new variables. No new Lambda env vars.**
+
+## Out of scope (do NOT port)
+
+The fork also carries `warm_pool_launch_auto_continue` (and its
+`WARM_POOL_LAUNCH_AUTO_CONTINUE` env var), which makes the Lambda *optionally leave
+the launching hook in Wait* so the instance can signal readiness itself. That is a
+**provisioning-readiness** concern, not a DNS concern, and conflates two
+responsibilities onto one hook. The correct pattern (see
+`terraform-aws-actions-runner`: separate `registration` and `bootstrap` launching
+hooks) is for the consumer to add its **own** bootstrap lifecycle hook that the
+instance completes. update-dns must stay single-purpose: manage a DNS record and
+complete its own hook. This flag is deliberately excluded; tetra-data will grow a
+dedicated bootstrap hook instead (tracked separately).
+
+## Backward compatibility
+
+Non-warm-pool consumers are unaffected: their events never carry `Origin=WarmPool`
+or `Destination=WarmPool`, so neither guard fires and behavior is byte-for-byte
+identical. Verified field presence (above) means there is no fall-through risk.
+No interface change (no new inputs/outputs), so this is a **minor** release.
+
+## Testing
+
+Unit tests (pytest) for `lambda_handler`, one per transition tuple from the table —
+asserting DNS side-effects and that the hook is completed in every case:
+
+- LAUNCHING `EC2->AutoScalingGroup` -> `add_records` called, hook CONTINUE
+- LAUNCHING `WarmPool->AutoScalingGroup` -> `add_records` called, hook CONTINUE
+- LAUNCHING `EC2->WarmPool` -> `add_records` NOT called, hook CONTINUE
+- TERMINATING `AutoScalingGroup->EC2` -> `remove_record` called, hook CONTINUE
+- TERMINATING `WarmPool->EC2` -> `remove_record` NOT called, hook CONTINUE (regression
+  test for the crash/hang)
+- Event with `Origin`/`Destination` absent -> behaves as today (add/remove) — guards
+  the positive-match contract.
+
+Integration: the existing pytest-infrahouse harness against a real ASG; if feasible,
+add a warm-pool variant that exercises pool entry + activation + trim.
+
+## Release
+
+Standard release flow (`make release-minor`; git-cliff + bumpversion own CHANGELOG /
+version — do not hand-edit). Ship as the next minor (e.g. 1.5.0).
+
+## Rollout / downstream
+
+Once released, the tetra-data fork can be retired: switch
+`modules/tetra-data/update-dns.tf` `source` back to the registry at the new version,
+delete the vendored `modules/tetra-data/modules/update-dns/`, and drop the
+`FILTER_BY_DESTINATION` / `WARM_POOL_LAUNCH_AUTO_CONTINUE` wiring — moving readiness
+to a dedicated bootstrap hook (tracked in the tetra-data issue).

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -75,8 +75,6 @@ def mocked_main(monkeypatch):
         "log_exception": log_exception,
     }
 
-    log_exception.assert_not_called()
-
 
 def _assert_hook_completed(asg):
     """The hook must always be completed with CONTINUE."""
@@ -200,3 +198,44 @@ def test_terminating_without_origin_destination_removes_record(mocked_main):
     )
     mocked_main["remove_record"].assert_called_once()
     _assert_hook_completed(mocked_main["asg"])
+
+
+# --- Exceptions must propagate, not be silently swallowed ---
+
+
+def test_add_records_failure_propagates(mocked_main):
+    """
+    A DNS failure on launch must propagate so the Lambda Errors metric fires and
+    EventBridge retries -- and the hook must NOT be completed with CONTINUE, since
+    the DNS work did not succeed.
+    """
+    mocked_main["add_records"].side_effect = RuntimeError("route53 boom")
+    with pytest.raises(RuntimeError, match="route53 boom"):
+        main.lambda_handler(
+            _make_event(
+                "autoscaling:EC2_INSTANCE_LAUNCHING",
+                LAUNCHING_HOOK,
+                origin="EC2",
+                destination="AutoScalingGroup",
+            ),
+            None,
+        )
+    mocked_main["asg"].return_value.complete_lifecycle_action.assert_not_called()
+    mocked_main["log_exception"].assert_called_once()
+
+
+def test_remove_record_failure_propagates(mocked_main):
+    """A DNS failure on termination must propagate (not be reported as success)."""
+    mocked_main["remove_record"].side_effect = RuntimeError("dynamodb boom")
+    with pytest.raises(RuntimeError, match="dynamodb boom"):
+        main.lambda_handler(
+            _make_event(
+                "autoscaling:EC2_INSTANCE_TERMINATING",
+                TERMINATING_HOOK,
+                origin="AutoScalingGroup",
+                destination="EC2",
+            ),
+            None,
+        )
+    mocked_main["asg"].return_value.complete_lifecycle_action.assert_not_called()
+    mocked_main["log_exception"].assert_called_once()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,202 @@
+"""
+Unit tests for the update-dns Lambda handler (``update_dns/main.py``).
+
+Unlike the integration tests in ``test_module.py`` (which stand up real AWS
+infrastructure via pytest-infrahouse), these are fast, hermetic tests of the
+``lambda_handler`` branching logic. They mock every AWS-touching dependency and
+assert which DNS side-effect runs and that the lifecycle hook is always
+completed -- in particular covering the warm-pool transitions that must skip DNS
+work (see the warm-pool-aware filtering change).
+"""
+
+import os
+import sys
+from os import path as osp
+from unittest.mock import MagicMock
+
+import pytest
+
+# ``update_dns/main.py`` lives in the Lambda build bundle. Append (not prepend)
+# the bundle dir so the installed infrahouse_core wins over the vendored copy.
+sys.path.append(osp.join(osp.dirname(osp.dirname(osp.abspath(__file__))), "update_dns"))
+
+import main  # noqa: E402  pylint: disable=wrong-import-position
+
+TERMINATING_HOOK = "terminating-hook"
+LAUNCHING_HOOK = "launching-hook"
+
+
+def _make_event(transition, hook_name, origin=None, destination=None):
+    """Build an EventBridge ASG lifecycle event, omitting absent Origin/Destination."""
+    detail = {
+        "EC2InstanceId": "i-0123456789abcdef0",
+        "LifecycleHookName": hook_name,
+        "LifecycleTransition": transition,
+        "AutoScalingGroupName": "asg-under-test",
+    }
+    if origin is not None:
+        detail["Origin"] = origin
+    if destination is not None:
+        detail["Destination"] = destination
+    return {"detail": detail}
+
+
+@pytest.fixture(autouse=True)
+def mocked_main(monkeypatch):
+    """
+    Patch every AWS-touching symbol in ``main`` and set the env vars the handler
+    reads. Yields the mocks so each test can assert on DNS calls and the hook.
+    """
+    monkeypatch.setenv("LIFECYCLE_HOOK_TERMINATING", TERMINATING_HOOK)
+    monkeypatch.setenv("LIFECYCLE_HOOK_LAUNCHING", LAUNCHING_HOOK)
+    monkeypatch.setenv("ROUTE53_ZONE_ID", "Z123456")
+    monkeypatch.setenv("ROUTE53_TTL", "300")
+    monkeypatch.setenv("LOCK_TABLE_NAME", "update-dns-lock")
+    # Custom hostname so resolve_hostnames() returns a static value without AWS calls.
+    monkeypatch.setenv("ROUTE53_HOSTNAME", "update-dns-test")
+
+    asg = MagicMock(name="ASG")
+    add_records = MagicMock(name="add_records")
+    remove_record = MagicMock(name="remove_record")
+    log_exception = MagicMock(name="LOG.exception")
+
+    monkeypatch.setattr(main, "ASG", asg)
+    monkeypatch.setattr(main, "DynamoDBTable", MagicMock(name="DynamoDBTable"))
+    monkeypatch.setattr(main, "add_records", add_records)
+    monkeypatch.setattr(main, "remove_record", remove_record)
+    # The handler swallows exceptions via LOG.exception; fail loudly instead so a
+    # broken mock setup can't masquerade as "the branch did nothing".
+    monkeypatch.setattr(main.LOG, "exception", log_exception)
+
+    yield {
+        "asg": asg,
+        "add_records": add_records,
+        "remove_record": remove_record,
+        "log_exception": log_exception,
+    }
+
+    log_exception.assert_not_called()
+
+
+def _assert_hook_completed(asg):
+    """The hook must always be completed with CONTINUE."""
+    asg.return_value.complete_lifecycle_action.assert_called_once()
+    _, kwargs = asg.return_value.complete_lifecycle_action.call_args
+    assert kwargs["result"] == "CONTINUE"
+    assert (
+        kwargs["hook_name"] == LAUNCHING_HOOK or kwargs["hook_name"] == TERMINATING_HOOK
+    )
+
+
+# --- Launching transitions ---
+
+
+def test_launching_cold_launch_adds_record(mocked_main):
+    """EC2 -> AutoScalingGroup: a real cold launch. DNS record is created."""
+    main.lambda_handler(
+        _make_event(
+            "autoscaling:EC2_INSTANCE_LAUNCHING",
+            LAUNCHING_HOOK,
+            origin="EC2",
+            destination="AutoScalingGroup",
+        ),
+        None,
+    )
+    mocked_main["add_records"].assert_called_once()
+    mocked_main["remove_record"].assert_not_called()
+    _assert_hook_completed(mocked_main["asg"])
+
+
+def test_launching_warm_pool_activation_adds_record(mocked_main):
+    """WarmPool -> AutoScalingGroup: instance activating out of the pool. DNS record is created."""
+    main.lambda_handler(
+        _make_event(
+            "autoscaling:EC2_INSTANCE_LAUNCHING",
+            LAUNCHING_HOOK,
+            origin="WarmPool",
+            destination="AutoScalingGroup",
+        ),
+        None,
+    )
+    mocked_main["add_records"].assert_called_once()
+    mocked_main["remove_record"].assert_not_called()
+    _assert_hook_completed(mocked_main["asg"])
+
+
+def test_launching_into_warm_pool_skips_add(mocked_main):
+    """EC2 -> WarmPool: instance entering the pool. No DNS record, but hook still completed."""
+    main.lambda_handler(
+        _make_event(
+            "autoscaling:EC2_INSTANCE_LAUNCHING",
+            LAUNCHING_HOOK,
+            origin="EC2",
+            destination="WarmPool",
+        ),
+        None,
+    )
+    mocked_main["add_records"].assert_not_called()
+    mocked_main["remove_record"].assert_not_called()
+    _assert_hook_completed(mocked_main["asg"])
+
+
+# --- Terminating transitions ---
+
+
+def test_terminating_in_service_removes_record(mocked_main):
+    """AutoScalingGroup -> EC2: a real in-service termination. DNS record is removed."""
+    main.lambda_handler(
+        _make_event(
+            "autoscaling:EC2_INSTANCE_TERMINATING",
+            TERMINATING_HOOK,
+            origin="AutoScalingGroup",
+            destination="EC2",
+        ),
+        None,
+    )
+    mocked_main["remove_record"].assert_called_once()
+    mocked_main["add_records"].assert_not_called()
+    _assert_hook_completed(mocked_main["asg"])
+
+
+def test_terminating_from_warm_pool_skips_remove(mocked_main):
+    """
+    WarmPool -> EC2: warmed instance being trimmed. It never held a DNS record.
+
+    Regression test: previously remove_record crashed on the missing IP tag, the
+    hook was never completed, and the ASG hung until HeartbeatTimeout -> ABANDON.
+    """
+    main.lambda_handler(
+        _make_event(
+            "autoscaling:EC2_INSTANCE_TERMINATING",
+            TERMINATING_HOOK,
+            origin="WarmPool",
+            destination="EC2",
+        ),
+        None,
+    )
+    mocked_main["remove_record"].assert_not_called()
+    mocked_main["add_records"].assert_not_called()
+    _assert_hook_completed(mocked_main["asg"])
+
+
+# --- Positive-match contract: missing fields fall through to today's behavior ---
+
+
+def test_launching_without_origin_destination_adds_record(mocked_main):
+    """Event with no Origin/Destination (non-warm-pool consumer) still adds the record."""
+    main.lambda_handler(
+        _make_event("autoscaling:EC2_INSTANCE_LAUNCHING", LAUNCHING_HOOK),
+        None,
+    )
+    mocked_main["add_records"].assert_called_once()
+    _assert_hook_completed(mocked_main["asg"])
+
+
+def test_terminating_without_origin_destination_removes_record(mocked_main):
+    """Event with no Origin/Destination (non-warm-pool consumer) still removes the record."""
+    main.lambda_handler(
+        _make_event("autoscaling:EC2_INSTANCE_TERMINATING", TERMINATING_HOOK),
+        None,
+    )
+    mocked_main["remove_record"].assert_called_once()
+    _assert_hook_completed(mocked_main["asg"])

--- a/update_dns/main.py
+++ b/update_dns/main.py
@@ -200,6 +200,12 @@ def lambda_handler(event, context):
     instance_id = event["detail"]["EC2InstanceId"]
     lc_hook_name = event["detail"]["LifecycleHookName"]
     lc_transition = event["detail"]["LifecycleTransition"]
+    # Warm-pool transitions are identified by the standard Origin/Destination fields.
+    # Positive-match on "WarmPool" (not != "AutoScalingGroup") so any event missing or
+    # carrying an unexpected value falls through to the normal add/remove behavior,
+    # keeping this change non-breaking for non-warm-pool consumers.
+    origin = event["detail"].get("Origin")
+    destination = event["detail"].get("Destination")
 
     if "LifecycleTransition" in event["detail"]:
         try:
@@ -207,6 +213,23 @@ def lambda_handler(event, context):
                 lc_hook_name == environ["LIFECYCLE_HOOK_TERMINATING"]
                 and lc_transition == "autoscaling:EC2_INSTANCE_TERMINATING"
             ):
+                if origin == "WarmPool":
+                    # Warm-pool instance being terminated (WarmPool -> EC2). It never
+                    # held a DNS record, and remove_record would crash on the missing
+                    # IP tag. Skip DNS and complete the hook so the ASG isn't left
+                    # waiting until HeartbeatTimeout -> ABANDON.
+                    LOG.info(
+                        f"Terminating event Origin=WarmPool on {instance_id}; "
+                        f"completing hook with no DNS removal."
+                    )
+                    ASG(
+                        event["detail"]["AutoScalingGroupName"]
+                    ).complete_lifecycle_action(
+                        hook_name=lc_hook_name,
+                        result="CONTINUE",
+                        instance_id=instance_id,
+                    )
+                    return
                 lock_ttl = int(os.getenv("LOCK_TTL", "60"))
                 with DynamoDBTable(os.getenv("LOCK_TABLE_NAME")).lock(
                     "update-dns", ttl=lock_ttl
@@ -228,6 +251,24 @@ def lambda_handler(event, context):
                 lc_hook_name == environ["LIFECYCLE_HOOK_LAUNCHING"]
                 and lc_transition == "autoscaling:EC2_INSTANCE_LAUNCHING"
             ):
+                if destination == "WarmPool":
+                    # Instance entering the warm pool (EC2 -> WarmPool). Not in service,
+                    # no traffic, possibly no stable IP -- no DNS record wanted. It will
+                    # be registered when it activates out of the pool
+                    # (Destination=AutoScalingGroup). Complete this module's hook now;
+                    # any readiness gating is the consumer's separate hook, not ours.
+                    LOG.info(
+                        f"Launching event Destination=WarmPool on {instance_id}; "
+                        f"completing hook with no DNS add."
+                    )
+                    ASG(
+                        event["detail"]["AutoScalingGroupName"]
+                    ).complete_lifecycle_action(
+                        hook_name=lc_hook_name,
+                        result="CONTINUE",
+                        instance_id=instance_id,
+                    )
+                    return
                 lock_ttl = int(os.getenv("LOCK_TTL", "60"))
                 with DynamoDBTable(os.getenv("LOCK_TABLE_NAME")).lock(
                     "update-dns", ttl=lock_ttl

--- a/update_dns/main.py
+++ b/update_dns/main.py
@@ -292,7 +292,16 @@ def lambda_handler(event, context):
                 LOG.warning("No action for this event.")
 
         except Exception as err:
+            # Log and re-raise: swallowing here reports the invocation as SUCCESS,
+            # which (a) skips the complete_lifecycle_action(CONTINUE) calls above so
+            # the hook is left in Wait until HeartbeatTimeout -> default_result, and
+            # (b) hides the failure from the Lambda Errors metric and EventBridge
+            # async retry, turning a transient Route53/DynamoDB error into a
+            # permanent one. Re-raising restores both. (Deliberately not ABANDON-
+            # then-raise: on a transient error we want the retry to recover, not
+            # tear the instance down.)
             LOG.exception(err)
+            raise
 
     else:
         LOG.warning("Event is not LifecycleTransition. Skip action.")


### PR DESCRIPTION
Two related-but-independent changes to the update-dns Lambda handler, in separate commits.

## 1. `feat:` skip DNS for warm-pool lifecycle transitions

The handler matched only on `LifecycleHookName` + `LifecycleTransition`, so it treated ASG **warm-pool** internal moves as real in-service launches/terminations. The moment a consumer enables a warm pool, this misbehaves:

- **LAUNCHING into the warm pool** (`Destination=WarmPool`): publishes a DNS record for an instance that serves no traffic and (in `Stopped`/`Hibernated` pools) has no stable IP.
- **TERMINATING from the warm pool** (`Origin=WarmPool`): a warmed instance never held a DNS record; `remove_record` crashes on the missing IP tag, the hook is never completed, and the ASG hangs until `HeartbeatTimeout` → `ABANDON`.

**Fix:** read `Origin`/`Destination` off the event and **positive-match on `"WarmPool"`** (not `!= "AutoScalingGroup"`):

- skip the add only when `Destination == "WarmPool"`
- skip the remove only when `Origin == "WarmPool"`

Any event missing or carrying an unexpected value falls through to today's add/remove behavior — **provably non-breaking** for non-warm-pool consumers (they only ever emit `Destination=AutoScalingGroup` on launch and `Origin=AutoScalingGroup`/`Destination=EC2` on terminate, so neither guard fires). In both skip cases the Lambda **still completes its own lifecycle hook with `CONTINUE`**; it just does no DNS work.

**Field presence verified in production:** a live warm-pool ASG over 45 days — 658 events, 0 missing either field. Observed transition taxonomy (≈35% of lifecycle traffic is the two cases the stock module handled wrong):

| Transition | Origin → Destination | DNS action |
|---|---|---|
| LAUNCHING | EC2 → **WarmPool** | **skip add** |
| LAUNCHING | WarmPool → AutoScalingGroup | add (activation) |
| LAUNCHING | EC2 → AutoScalingGroup | add (cold launch) |
| TERMINATING | AutoScalingGroup → EC2 | remove |
| TERMINATING | **WarmPool** → EC2 | **skip remove** |

**Out of scope (deliberately not ported from the downstream fork):** `warm_pool_launch_auto_continue` / leaving the launching hook in `Wait` for instance-readiness signalling. That's a provisioning-readiness concern, not a DNS one; the consumer should add its own bootstrap lifecycle hook. update-dns stays single-purpose: manage a DNS record and complete its own hook. No new variables, no new Lambda env vars.

## 2. `fix:` re-raise in the lifecycle handler instead of muting exceptions

The `LifecycleTransition` block ended with `except Exception: LOG.exception(err)` — log and return normally, so a failed invocation is reported as **SUCCESS**. Three bad consequences:

1. The `complete_lifecycle_action(CONTINUE)` calls live *inside* the try, after `add_records`/`remove_record`. If those throw, CONTINUE is skipped and the hook is left in `Wait` until `HeartbeatTimeout` → `default_result` (ABANDON for most consumers) → the instance hangs and is replaced.
2. Returning success means the Lambda `Errors` metric never increments and EventBridge async retry never fires — a transient Route53/DynamoDB error becomes a permanent one-shot failure.
3. It's invisible to alarms; the only trace is a log line.

Also violates the coding standard ("never bare `except Exception`", "better to crash than mute silently"). Fix is log-and-propagate (`raise`), which restores the `Errors` metric + EventBridge retry and lets the heartbeat handle a genuinely stuck hook.

**Considered alternative — ABANDON-then-raise:** rejected here. On a *transient* error we want the retry to recover, not tear the instance down. Re-raise leaves recovery to retry + heartbeat.

**Production evidence:** on the tetra-data deployment this block caught `KeyError: 'PublicIpAddress'` 8 times in a 75-min window (2026-05-14), all on warm-pool terminations — each a hook silently left uncompleted, reported as success. The same upstream code runs on the agentql-logs and playground-logs clusters; it simply hasn't been provoked there because they don't run a warm pool. So the mute is a **latent correctness bug for every consumer, independent of the warm-pool feature** — which is why it's its own commit.

### Audit of the other `except Exception` (main.py:115)
Checked per review, **left unchanged**: it's the per-record delete loop in `remove_records` — catches a single record's delete failure, logs, increments `failed_count`, and **raises after the loop if `deleted_count == 0`**. That's the acceptable aggregate-then-raise pattern, not a silent mute. Could narrow the catch to the specific Route53 exception, but that's out of scope here.

## Tests
New `tests/test_main.py` — fast, hermetic unit tests of `lambda_handler` (mock all AWS deps; no infrastructure). 9 cases:
- every transition tuple (cold launch / warm-pool activation / into-warm-pool / in-service terminate / warm-pool trim)
- missing `Origin`/`Destination` → falls through to add/remove (guards the positive-match contract)
- `add_records` raising → handler raises and CONTINUE **not** called
- `remove_record` raising → handler raises

The existing pytest-infrahouse integration suite (`test_module.py`) passes unchanged.

## Release
Backward-compatible; no interface change (no new inputs/outputs). Lands as the next **minor** via `make release-minor` at merge time — git-cliff + bumpversion own CHANGELOG/version, not hand-edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)