### PR TITLE
fix: pin cryptography floor in lambda deps (GHSA-537c-gmf6-5ccf)

### DIFF
--- a/update_dns/requirements.txt
+++ b/update_dns/requirements.txt
@@ -1,1 +1,7 @@
-infrahouse-core == 0.26.1
+infrahouse-core ~= 1.0
+
+# Security floor for a transitive dependency (pulled in via infrahouse-core ->
+# PyGithub -> PyJWT). cryptography wheels < 48.0.1 statically link a vulnerable
+# OpenSSL (GHSA-537c-gmf6-5ccf). Floor only -- cryptography bumps its major
+# frequently, so a ~= pin would go stale.
+cryptography >= 48.0.1


### PR DESCRIPTION
cryptography wheels < 48.0.1 statically link a vulnerable OpenSSL. It is
pulled in transitively via infrahouse-core -> PyGithub -> PyJWT, so the
lambdas can package a vulnerable version even though they never declare
cryptography directly.

infrahouse-core >= 1.1.2 now carries this floor upstream; these local
floors are a path-independent, regression-proof safety net that keeps the
constraint next to the affected package for scanners/auditors. Floor only
because cryptography bumps its major frequently (49.x already out), so a
~= pin would go stale.
